### PR TITLE
Translated CodeEditor.

### DIFF
--- a/src/components/CodeEditor/CodeEditor.js
+++ b/src/components/CodeEditor/CodeEditor.js
@@ -105,7 +105,7 @@ class CodeEditor extends Component {
                 color: colors.white,
               }}>
               <MetaTitle onDark={true}>
-                Live JSX Editor
+                Live JSX-redigerare
                 <label
                   css={{
                     fontSize: 14,
@@ -175,7 +175,7 @@ class CodeEditor extends Component {
                   cssProps={{
                     color: colors.white,
                   }}>
-                  Error
+                  Fel
                 </MetaTitle>
               </div>
               <pre
@@ -206,7 +206,7 @@ class CodeEditor extends Component {
                   padding: '0 10px',
                   backgroundColor: colors.divider,
                 }}>
-                <MetaTitle>Result</MetaTitle>
+                <MetaTitle>Resultat</MetaTitle>
               </div>
               <div
                 id={containerNodeID}


### PR DESCRIPTION
As part of #3 I translated the words in the `CodeEditor` component. Sending it here as a separate PR.
